### PR TITLE
Added nil check for itemID

### DIFF
--- a/TSM_PriceChecker/Modules/EventDetection.lua
+++ b/TSM_PriceChecker/Modules/EventDetection.lua
@@ -26,6 +26,11 @@ function Util:Process(message, recipient, channel)
 	end
 
 	local itemID  = TSM_API.ToItemString(itemString)
+	local itemID  = TSM_API.ToItemString(itemString)
+	if itemID == nil or itemID == nill then
+		Util:SendMessage("No such item {Skull} ", recipient, channel)
+		return
+	end
 
 	local priceMarket = TSM_API.GetCustomPriceValue(TSM.db.global["MarketSource"], itemID)
 	local priceMin = TSM_API.GetCustomPriceValue(TSM.db.global["MinBuyoutSource"], itemID)

--- a/TSM_PriceChecker/Modules/EventDetection.lua
+++ b/TSM_PriceChecker/Modules/EventDetection.lua
@@ -27,7 +27,7 @@ function Util:Process(message, recipient, channel)
 
 	local itemID  = TSM_API.ToItemString(itemString)
 	local itemID  = TSM_API.ToItemString(itemString)
-	if itemID == nil or itemID == nill then
+	if itemID == nil then
 		Util:SendMessage("No such item {Skull} ", recipient, channel)
 		return
 	end

--- a/TSM_PriceChecker/Modules/EventDetection.lua
+++ b/TSM_PriceChecker/Modules/EventDetection.lua
@@ -25,8 +25,7 @@ function Util:Process(message, recipient, channel)
 		end
 	end
 
-	local itemID  = TSM_API.ToItemString(itemString)
-	local itemID  = TSM_API.ToItemString(itemString)
+	local itemID = TSM_API.ToItemString(itemString)
 	if itemID == nil then
 		Util:SendMessage("No such item {Skull} ", recipient, channel)
 		return


### PR DESCRIPTION
Querying item (eg. trigger +"ASD") that doesn't exist would return error message for the addon owner:

Message: ...eSkillMaster_PriceChecker\Modules\EventDetection.lua line 34:
   Invalid 'itemString' argument type (must be a TSM item string): nil
...
...

Now handles the nil error and returns "No such item {Skull}" for the recipient instead.