### PR TITLE
Support for strings & small modifications

### DIFF
--- a/TSM_PriceChecker/Modules/EventDetection.lua
+++ b/TSM_PriceChecker/Modules/EventDetection.lua
@@ -26,6 +26,11 @@ function Util:Process(message, recipient, channel)
 	end
 
 	local itemID  = TSM_API.ToItemString(itemString)
+	local itemID  = TSM_API.ToItemString(itemString)
+	if itemID == nil or itemID == nill then
+		Util:SendMessage("No such item {Skull} ", recipient, channel)
+		return
+	end
 
 	local priceMarket = TSM_API.GetCustomPriceValue(TSM.db.global["MarketSource"], itemID)
 	local priceMin = TSM_API.GetCustomPriceValue(TSM.db.global["MinBuyoutSource"], itemID)

--- a/TSM_PriceChecker/Modules/EventDetection.lua
+++ b/TSM_PriceChecker/Modules/EventDetection.lua
@@ -24,13 +24,17 @@ function Util:Process(message, recipient, channel)
 			itemCount = 1
 		end
 	end
-
+	
 	local itemID = TSM_API.ToItemString(itemString)
-	if itemID == nil then
-		Util:SendMessage("No such item {Skull} ", recipient, channel)
-		return
-	end
-
+		if itemID == nil then
+			local itemName, itemLink, itemRarity, itemLevel, itemMinLevel, itemType,itemSubType, itemStackCount, itemEquipLoc, itemTexture, itemSellPrice = GetItemInfo("".. itemString .."")
+			if itemLink ~= nil then
+				itemID = TSM_API.ToItemString(itemLink)
+			else
+				Util:SendMessage("No such item {Skull} ", recipient, channel)
+				return
+			end
+		end
 	local priceMarket = TSM_API.GetCustomPriceValue(TSM.db.global["MarketSource"], itemID)
 	local priceMin = TSM_API.GetCustomPriceValue(TSM.db.global["MinBuyoutSource"], itemID)
 	--Trying GetCustomPriceValue, though I'm not certain it's wise to allow modified prices here.
@@ -47,8 +51,8 @@ function Util:Process(message, recipient, channel)
 		priceRegion = TSM_API.GetCustomPriceValue(TSM.db.global["Region"], itemID)
 	end
 
-	if itemID == nill then
-	end
+	-- if itemID == nill then
+	-- end
 
 	if itemID == nill then
 		return

--- a/TSM_PriceChecker/Modules/EventDetection.lua
+++ b/TSM_PriceChecker/Modules/EventDetection.lua
@@ -27,7 +27,7 @@ function Util:Process(message, recipient, channel)
 
 	local itemID  = TSM_API.ToItemString(itemString)
 	local itemID  = TSM_API.ToItemString(itemString)
-	if itemID == nil or itemID == nill then
+	if itemID == nil then
 		Util:SendMessage("No such item {Skull} ", recipient, channel)
 		return
 	end

--- a/TSM_PriceChecker/Modules/EventDetection.lua
+++ b/TSM_PriceChecker/Modules/EventDetection.lua
@@ -25,8 +25,7 @@ function Util:Process(message, recipient, channel)
 		end
 	end
 
-	local itemID  = TSM_API.ToItemString(itemString)
-	local itemID  = TSM_API.ToItemString(itemString)
+	local itemID = TSM_API.ToItemString(itemString)
 	if itemID == nil then
 		Util:SendMessage("No such item {Skull} ", recipient, channel)
 		return

--- a/TSM_PriceChecker/Modules/Options.lua
+++ b/TSM_PriceChecker/Modules/Options.lua
@@ -173,21 +173,21 @@ local options = {
 				guildchannel = {
 						type = 'input',
 						name = 'Channel to reply for guild messages',
-						desc = '/tsmpc guild CHANNEL',
+						desc = '/tsmpc guildchannel CHANNEL',
 						set = 'SetGuildChannel',
 				},
 				--PartyChannel
 				partychannel = {
 						type = 'input',
 						name = 'Channel to reply for party messages',
-						desc = '/tsmpc party CHANNEL',
+						desc = '/tsmpc partychannel CHANNEL',
 						set = 'SetPartyChannel',
 				},
 				--OfficerChannel
 				officerchannel = {
 						type = 'input',
 						name = 'Channel to reply for officer messages',
-						desc = '/tsmpc officer CHANNEL',
+						desc = '/tsmpc officerchannel CHANNEL',
 						set = 'SetOfficerChannel',
 				},
     },

--- a/TSM_PriceChecker/Modules/Util.lua
+++ b/TSM_PriceChecker/Modules/Util.lua
@@ -71,17 +71,17 @@ function Util:ValuesFor(marketPrice, marketName, itemCount)
 
 	if TSM.db.global["ShowCopper"] then
 		if itemCount > 1 then
-			copper = "s"..multipliedMarketCopper
+			copper = "s "..multipliedMarketCopper
 		else
-			copper = "s"..marketCopper
+			copper = "s "..marketCopper
 		end
 
-		gold = "g"
+		gold = "g "
 
 		if TSM.db.global["UseRaidIcon"] then
-			icon = "c{rt2}"
+			icon = "c {rt2}"
 		else
-			icon = "c"
+			icon = "c "
 		end
 	end
 

--- a/TSM_PriceChecker/Modules/Util.lua
+++ b/TSM_PriceChecker/Modules/Util.lua
@@ -73,7 +73,7 @@ function Util:ValuesFor(marketPrice, marketName, itemCount)
 		if itemCount > 1 then
 			copper = "s "..multipliedMarketCopper
 		else
-			copper = "s "..marketCopper
+			copper = "s"..marketCopper
 		end
 
 		gold = "g "
@@ -81,7 +81,7 @@ function Util:ValuesFor(marketPrice, marketName, itemCount)
 		if TSM.db.global["UseRaidIcon"] then
 			icon = "c {rt2}"
 		else
-			icon = "c "
+			icon = "c"
 		end
 	end
 


### PR DESCRIPTION
.. Sorry for not using branches with this one.

- Users can search with itemlinks or strings
_!price [Runecloth]
!price Runecloth_
- Fixed descriptions of channels
eg. _desc = '/tsmpc guild CHANNEL'_ **-->** _desc = '/tsmpc guildchannel CHANNEL'_
- Price message cleanup
eg. brackets, no raid icon: _Min [0g 10s 33c] Market [0g 9s 92c] Regional [0g 8s 62c]_